### PR TITLE
Set field createdAt as sortable on shop_page grid

### DIFF
--- a/src/Resources/config/grids/shop/page.yml
+++ b/src/Resources/config/grids/shop/page.yml
@@ -15,4 +15,5 @@ sylius_grid:
             fields:
                 createdAt:
                     type: datetime
+                    sortable: ~
             limits: [10]


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets |
| License         | MIT

Otherwise the sorting does not work. 
```
sorting:
  createdAt: desc
```
As indicated from this sorting definition, the newest pages are supposed to show up first.
